### PR TITLE
Add extra check to run travis check scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,14 @@ tasks.coveralls {
     onlyIf { System.env.'CI' }
 }
 
+task extrachecks(type: Exec) {
+    commandLine 'bash', './config/travis/run-checks.sh'
+}
+
+tasks.check {
+    dependsOn extrachecks
+}
+
 test {
     testLogging {
         events TestLogEvent.FAILED, TestLogEvent.SKIPPED


### PR DESCRIPTION
Fix an issue with repeatedly getting extra errors on Travis. See https://github.com/nus-cs2103-AY1920S1/forum/issues/140