### PR TITLE
Revert default plantuml fontsize change 

### DIFF
--- a/docs/diagrams/style.puml
+++ b/docs/diagrams/style.puml
@@ -42,7 +42,6 @@ skinparam Class {
     BorderThickness 1
     BorderColor #FFFFFF
     StereotypeFontColor #FFFFFF
-    FontSize 11
     FontName Arial
 }
 


### PR DESCRIPTION
The generated plantuml images are too big (if not downscaled) in comparison to the website's font.

![image](https://user-images.githubusercontent.com/43642522/67452050-b7a15480-f654-11e9-9d1e-50599af23e4d.png)

This PR fixes that.