### PR TITLE
Fix issue when too many arguments are given to some commands

### DIFF
--- a/src/main/java/seedu/module/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/module/logic/parser/AddCommandParser.java
@@ -24,6 +24,11 @@ public class AddCommandParser implements Parser<AddCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
+        if (trimmedArgs.split("\\s+").length > 1) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Module code should be a single word only."));
+        }
+
         return new AddCommand(new SameModuleCodePredicate(trimmedArgs));
     }
 

--- a/src/main/java/seedu/module/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/module/logic/parser/DeleteCommandParser.java
@@ -24,6 +24,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
+        if (trimmedArgs.split("\\s+").length > 1) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Module code should be a single word only."));
+        }
+
         return new DeleteCommand(new SameModuleCodePredicate(trimmedArgs));
     }
 

--- a/src/main/java/seedu/module/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/module/logic/parser/ViewCommandParser.java
@@ -23,6 +23,11 @@ public class ViewCommandParser implements Parser<ViewCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
+        if (trimmedArgs.split("\\s+").length > 1) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, "Module code should be a single word only."));
+        }
+
         return new ViewCommand(trimmedArgs);
     }
 


### PR DESCRIPTION
For example, `add cs 2103t` will not display a command failure message.