### PR TITLE
Do not display urls in html to pdf conversion

### DIFF
--- a/docs/stylesheets/gh-pages.css
+++ b/docs/stylesheets/gh-pages.css
@@ -211,4 +211,8 @@ table.tableblock > .title,
     #site-header {
         display: none;
     }
+    
+    a[href]:after {
+      content: none !important;
+    }
 }

--- a/docs/stylesheets/gh-pages.css
+++ b/docs/stylesheets/gh-pages.css
@@ -211,7 +211,7 @@ table.tableblock > .title,
     #site-header {
         display: none;
     }
-    
+
     a[href]:after {
       content: none !important;
     }


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/43642522/68562036-f885cf80-0482-11ea-9b84-f0333669c27f.png)

Solution:
Remove hyperlink urls from html to pdf conversion